### PR TITLE
Opal codegen

### DIFF
--- a/codegen.py
+++ b/codegen.py
@@ -584,7 +584,7 @@ def ap_op_stmt(op_list, sub_point, id_dict, id_dict_true, level, curr_id, dest, 
     valid_op_list = [x for x in op_list if x in valid_op_list]
 
     if(len(valid_op_list) == 1):
-        if(mode == "onyx"):
+        if(mode == "onyx" or mode == "opal"):
             stmt = "    " * (level + 2) + "/* Reserved operation */"
 
     for op in op_list: 
@@ -659,7 +659,7 @@ def cp_op_stmt(op_list, sub_point, id_dict, id_dict_true, level, curr_id, mode, 
         valid_op_list = [x for x in op_list if x in valid_op_list]
     
         if(len(valid_op_list) == 1):
-            if(mode == "onyx"):
+            if(mode == "onyx" or mode == "opal"):
                 stmt = "    " * (level + 2) + "/* Reserved operation */"
 
         if(unroll): 
@@ -670,7 +670,7 @@ def cp_op_stmt(op_list, sub_point, id_dict, id_dict_true, level, curr_id, mode, 
         for op in op_list: 
             if op in valid_op_list: 
                 if(len(valid_op_list) != 1):
-                    if(mode == "onyx"): 
+                    if(mode == "onyx" or mode == "opal"): 
                         stmt = stmt + "    " * (level + 2)
                         stmt = stmt + "if(!store_" + op + "1[id_store_" + op + "] && ((curr_subtile_num % " + str(unroll_factor) + ") == 0)){"
                         stmt = stmt + "\n"
@@ -699,7 +699,7 @@ def cp_op_stmt(op_list, sub_point, id_dict, id_dict_true, level, curr_id, mode, 
 
             if op not in valid_op_list: 
                 if(len(valid_op_list) != 1 or mode == "rtl"):    
-                    if(mode == "onyx"):
+                    if(mode == "onyx" or mode == "opal"):
                         stmt = stmt + "    " * (level + 2)
                         stmt += "id_store_" + op + " = " + "store_size_" + op + ";"
                         stmt += "\n"
@@ -728,7 +728,7 @@ def cp_op_stmt(op_list, sub_point, id_dict, id_dict_true, level, curr_id, mode, 
         if(valid_op_list != []):
             if(len(valid_op_list) != 1 or mode == "rtl"):
 
-                if(mode == "onyx"):
+                if(mode == "onyx" or mode == "opal"):
                     stmt += "    " * (level + 2)  + "if((curr_subtile_num % " + str(unroll_factor) + ") == 0){\n"
                     for op in op_list:
                         stmt += "    " * (level + 3)                        
@@ -799,7 +799,7 @@ def cp_op_stmt(op_list, sub_point, id_dict, id_dict_true, level, curr_id, mode, 
                     stmt += "else\n"
                     stmt += "    " * (level + 3)
                     stmt += "assert(0 && \"mode must be \'reduce\' or \'tiling\'\");\n"
-                elif(mode == "onyx"):
+                elif(mode == "onyx" or mode == "opal"):
                     stmt += "    " * (level + 2)
                     stmt += "partial = subtile_gold" + "(" + "subtile_" + op_list[0]
                     for op in op_list[1:]:  

--- a/main.py
+++ b/main.py
@@ -509,8 +509,9 @@ if __name__ == "__main__":
     if mode == "onyx":
         mapping_dict = mapping_dict_gen(args.design)
         main_file = open("lego_scratch/main.c", "w+")
-        main_gen_header_files(main_file)
-        main_spec_header_files(main_file, app_name)
+        main_gen_c_lib_include(main_file)
+        main_app_header_include(main_file, app_name)
+        main_gen_soc_lib_include(main_file)
         main_block_1(main_file)
         main_block_2(main_file, mapping_dict, op_list)
         main_block_3(main_file, mapping_dict, dest_read)    

--- a/main.py
+++ b/main.py
@@ -341,7 +341,6 @@ def cp_closing_decleration(main_file, cg_source_id, cg_source_map, op_list, mode
             
             tensor_dim = len(value)
 
-            print(mode_list)
             # TODO: Introduce systematic change to replace this hack
             # this hack is to cope with the old RTL bitstream generation that 
             # always place the matrix modes in the data flow order 

--- a/main.py
+++ b/main.py
@@ -466,7 +466,9 @@ if __name__ == "__main__":
                     description="Generate Cpp code for tiling and reduction given the input program and tensors")
     parser.add_argument("-t", "--tensor", type=str, default="./input/tensor.txt")
     parser.add_argument("-p", "--program", type=str, default="./input/program.txt")
-    parser.add_argument("-d", "--design", type=str, default="./input/design_meta.json")
+    parser.add_argument("--bitstream", type=str, default="./input/bitstream.bs")
+    parser.add_argument("--design_meta", type=str, default="./input/design_meta.json")
+    parser.add_argument("--reg_write", type=str, default="./input/reg_write.h")
     parser.add_argument("-m", "--mode", type=str, default="rtl")
     parser.add_argument("-b", "--comal_batch_size", type=int, default=100000)
     parser.add_argument("-g", "--gold_check", choices=["s", "d", "none"], default = "none")
@@ -507,7 +509,7 @@ if __name__ == "__main__":
     mode = args.mode
 
     if mode == "onyx":
-        mapping_dict = mapping_dict_gen(args.design)
+        mapping_dict = mapping_dict_gen(args.design_meta)
         main_file = open("lego_scratch/main.c", "w+")
         main_gen_c_lib_include(main_file)
         main_app_header_include(main_file, app_name)
@@ -516,12 +518,12 @@ if __name__ == "__main__":
         main_block_2(main_file, mapping_dict, op_list)
         main_block_3(main_file, mapping_dict, dest_read)    
 
-        inputs, outputs, input_order, output_order, bitstream_name = meta_scrape(args.design)
+        inputs, outputs, input_order, output_order, bitstream_name = meta_scrape(args.design_meta)
 
         unrolling_header_file = open("lego_scratch/" + app_name + "_unrolling.h", "w+")
         unrolling(inputs, outputs, input_order, output_order, unrolling_header_file, app_name)
 
-        bitstream_file = "./input/bitstream.bs"
+        bitstream_file = args.bitstream 
         bitstream_header_file = open("lego_scratch/" + app_name + "_script.h", "w+")
         convert_bs(bitstream_file, bitstream_header_file)
 
@@ -531,7 +533,7 @@ if __name__ == "__main__":
         linker_header_file.write(generate_data_location_content(input_list))
         bottom_half_of_body(linker_header_file)
 
-        reg_write_file = "./input/reg_write.h"
+        reg_write_file = args.reg_write
         with open(reg_write_file, 'r') as file:
             data = file.read()
             data = data.replace('glb_reg_write', 'HAL_Cgra_Glb_WriteReg')

--- a/main.py
+++ b/main.py
@@ -341,6 +341,7 @@ def cp_closing_decleration(main_file, cg_source_id, cg_source_map, op_list, mode
             
             tensor_dim = len(value)
 
+            print(mode_list)
             # TODO: Introduce systematic change to replace this hack
             # this hack is to cope with the old RTL bitstream generation that 
             # always place the matrix modes in the data flow order 
@@ -351,8 +352,8 @@ def cp_closing_decleration(main_file, cg_source_id, cg_source_map, op_list, mode
                 mode_list.sort()
 
             for i in range(0, tensor_dim):
-                main_file.write("            " + "mode_data_printer(input_data_file, \"" + key + "\", \"" + str(cg_source_map[key][i]) + "\", cg_subtile_" + key + "1.mode_" + str(i) + ");\n")
-                main_file.write("            " + "extent_data_printer(input_meta_data_file, \"" + key + "\", \"" + str(cg_source_map[key][i]) + "\", cg_extents_" + key + "1.extents_mode_" + str(i) + ");\n")
+                main_file.write("            " + "mode_data_printer(input_data_file, \"" + key + "\", \"" + str(cg_source_map_cpy[key][i]) + "\", cg_subtile_" + key + "1.mode_" + str(i) + ");\n")
+                main_file.write("            " + "extent_data_printer(input_meta_data_file, \"" + key + "\", \"" + str(cg_source_map_cpy[key][i]) + "\", cg_extents_" + key + "1.extents_mode_" + str(i) + ");\n")
                 main_file.write("\n")
 
             main_file.write("            " + "val_data_printer(input_data_file, \"" + key + "\", \"vals\", cg_subtile_" + key + "1.mode_vals, \"" + dtype + "\");\n")

--- a/main.py
+++ b/main.py
@@ -625,7 +625,7 @@ if __name__ == "__main__":
         linker_header_file = open("lego_scratch/sections.ld", "w+")
         first_half_of_body(linker_header_file)
         input_list = [input.strip(".raw") for input in inputs]
-        linker_header_file.write(generate_data_location_content(input_list, glb_tile_offset))
+        linker_header_file.write(generate_data_location_content(input_list, input_order, glb_tile_offset))
         if(unroll): 
             linker_header_file.write(generate_data_location_content_unroll(input_list, glb_tile_offset))
         bottom_half_of_body(linker_header_file)

--- a/main.py
+++ b/main.py
@@ -714,7 +714,7 @@ if __name__ == "__main__":
     main_file.write("float* subtile_gold" + stmt + " {\n")
     cg_tensor_decleration(main_file, cg_source_id, cg_split_factor, cg_dest_id, scalar)
 
-    for element in codegen.lower(expr, cg_source_id, cg_source_id, op_list, cg_schedule, 1, "cg", cg_split_factor, cg_dest_id, mode, cg_source_id, cg_source_map, scalar, workspace, process_csf, dtype):
+    for element in codegen.lower(expr, cg_source_id, cg_source_id, op_list, cg_schedule, 1, "cg", cg_split_factor, cg_dest_id, mode, cg_source_id, cg_source_map, scalar, workspace, process_csf, unroll, dtype):
         if element != [""]:
             main_file.write(element[0])
             main_file.write("\n")

--- a/main.py
+++ b/main.py
@@ -387,9 +387,9 @@ def cp_closing_decleration(main_file, cg_source_id, cg_source_map, op_list, mode
         main_file.write("        " + "output_gold_file.open(output_gold_path, std::ios_base::app);\n")
 
         if(unroll): 
-            main_file.write("        " + "codegen_check_gold_head(output_gold_file, curr_subtile_num, " + str(out_tensor_dim) + ", 1, \"" + glb_tile_offset + "\");\n")
+            main_file.write("        " + "codegen_check_gold_head(output_gold_file, curr_subtile_num, " + str(out_tensor_dim) + ", 1, \"" + glb_bank_offset + "\");\n")
         else: 
-            main_file.write("        " + "codegen_check_gold_head(output_gold_file, curr_subtile_num, " + str(out_tensor_dim) + ", 0, \"" + glb_tile_offset + "\");\n")
+            main_file.write("        " + "codegen_check_gold_head(output_gold_file, curr_subtile_num, " + str(out_tensor_dim) + ", 0, \"" + glb_bank_offset + "\");\n")
 
         if(unroll):
             main_file.write("        " + "codegen_check_gold_unroll_ifdef_open(output_gold_file, 1);\n")

--- a/onyx_codegen/generate_linker.py
+++ b/onyx_codegen/generate_linker.py
@@ -234,18 +234,17 @@ libgcc.a ( * )
 }"""
     f.write(string)
 
-def generate_data_location_content(data_list, glb_tile_offset):
+def generate_data_location_content(data_list, data_order, glb_tile_offset):
     result = ""
-    increment = 0x00000
     base_location = 0x20400000
 
-    for data_name in data_list:
-        current_location = hex(base_location + increment)[2:]
+    for idx, data_name in enumerate(data_list):
+        data_tile_offset = data_order[idx][0] * int(glb_tile_offset, 16)
+        current_location = hex(base_location + data_tile_offset)[2:]
         result += f".data_at_specific_location 0x{current_location} : {{\n"
         result += f"    *(.app_{data_name}_data)\n"
         result += f"    KEEP(*(.app_{data_name}_data))\n"
         result += "}\n"
-        increment += int(glb_tile_offset, 16)
 
     return result
 

--- a/onyx_codegen/generate_linker.py
+++ b/onyx_codegen/generate_linker.py
@@ -245,7 +245,7 @@ def generate_data_location_content(data_list, glb_tile_offset):
         result += f"    *(.app_{data_name}_data)\n"
         result += f"    KEEP(*(.app_{data_name}_data))\n"
         result += "}\n"
-        increment += glb_tile_offset
+        increment += int(glb_tile_offset, 16)
 
     return result
 
@@ -260,6 +260,6 @@ def generate_data_location_content_unroll(data_list, glb_tile_offset):
         result += f"    *(.app_{data_name}_unroll_data)\n"
         result += f"    KEEP(*(.app_{data_name}_unroll_data))\n"
         result += "}\n"
-        increment += glb_tile_offset
+        increment += int(glb_tile_offset, 16)
 
     return result

--- a/onyx_codegen/generate_linker.py
+++ b/onyx_codegen/generate_linker.py
@@ -234,7 +234,7 @@ libgcc.a ( * )
 }"""
     f.write(string)
 
-def generate_data_location_content(data_list):
+def generate_data_location_content(data_list, glb_tile_offset):
     result = ""
     increment = 0x00000
     base_location = 0x20400000
@@ -245,11 +245,11 @@ def generate_data_location_content(data_list):
         result += f"    *(.app_{data_name}_data)\n"
         result += f"    KEEP(*(.app_{data_name}_data))\n"
         result += "}\n"
-        increment += 0x20000
+        increment += glb_tile_offset
 
     return result
 
-def generate_data_location_content_unroll(data_list):
+def generate_data_location_content_unroll(data_list, glb_tile_offset):
     result = ""
     increment = 0x00000
     base_location = 0x20600000
@@ -260,6 +260,6 @@ def generate_data_location_content_unroll(data_list):
         result += f"    *(.app_{data_name}_unroll_data)\n"
         result += f"    KEEP(*(.app_{data_name}_unroll_data))\n"
         result += "}\n"
-        increment += 0x40000
+        increment += glb_tile_offset
 
     return result

--- a/onyx_codegen/generate_linker.py
+++ b/onyx_codegen/generate_linker.py
@@ -245,6 +245,6 @@ def generate_data_location_content(data_list):
         result += f"    *(.app_{data_name}_data)\n"
         result += f"    KEEP(*(.app_{data_name}_data))\n"
         result += "}\n"
-        increment += 0x40000
+        increment += 0x20000
 
     return result

--- a/onyx_codegen/generate_reg_write.py
+++ b/onyx_codegen/generate_reg_write.py
@@ -5,12 +5,18 @@ def generate_reg_write(input_reg_write_path, glb_tile_offset, glb_bank_offset):
     # TODO: app currently only uses up to 10 input glb tiles, need to change this to be more general
     for i in range(0, 10):
         input_glb_tile_offset = int(glb_tile_offset, 16) * i
-        reg_write_input_list.append(f"0x{i}80, {hex(input_glb_tile_offset)} + {glb_tile_offset} * i")
+        if i != 0:
+            reg_write_input_list.append(f"0x{i}80, {hex(input_glb_tile_offset)}")
+        else:
+            reg_write_input_list.append(f"0x80, {hex(input_glb_tile_offset)}")
 
     # TODO: app currently only uses up to 4 output glb tiles, need to change this to be more general
     for i in range(0, 4):
         ouput_glb_tile_offset = int(glb_tile_offset, 16) * i + int(glb_bank_offset, 16)
-        reg_write_output_list.append(f"0x{i}1c, {hex(ouput_glb_tile_offset)} + {glb_tile_offset} * i")
+        if i != 0:
+            reg_write_output_list.append(f"0x{i}1c, {hex(ouput_glb_tile_offset)}")
+        else:
+            reg_write_output_list.append(f"0x1c, {hex(ouput_glb_tile_offset)}")
 
     # replace the SoC function calls with the HAL function calls
     # also replace address and the data for input and output glb tiles  
@@ -18,9 +24,9 @@ def generate_reg_write(input_reg_write_path, glb_tile_offset, glb_bank_offset):
         data = file.read()
         data = data.replace('glb_config()', 'glb_config(int i)')
         for item in reg_write_input_list:
-            data = data.replace(item, item)
+            data = data.replace(item, item + f" + {glb_tile_offset} * i")
         for item in reg_write_output_list:
-            data = data.replace(item, item)
+            data = data.replace(item, item + f" + {glb_tile_offset} * i")
         data = data.replace('glb_reg_write(', 'HAL_Cgra_Glb_WriteReg(0x100 * i + ')
 
     return data

--- a/onyx_codegen/generate_reg_write.py
+++ b/onyx_codegen/generate_reg_write.py
@@ -1,0 +1,28 @@
+def generate_reg_write(input_reg_write_path, glb_tile_offset, glb_bank_offset):
+    reg_write_input_list = []
+    reg_write_output_list = []
+
+    # TODO: app currently only uses up to 10 input glb tiles, need to change this to be more general
+    for i in range(0, 10):
+        input_glb_tile_offset = int(glb_tile_offset, 16) * i
+        reg_write_input_list.append(f"0x{i}80, {hex(input_glb_tile_offset)} + {glb_tile_offset} * i")
+
+    # TODO: app currently only uses up to 4 output glb tiles, need to change this to be more general
+    for i in range(0, 4):
+        ouput_glb_tile_offset = int(glb_tile_offset, 16) * i + int(glb_bank_offset, 16)
+        reg_write_output_list.append(f"0x{i}1c, {hex(ouput_glb_tile_offset)} + {glb_tile_offset} * i")
+
+    # replace the SoC function calls with the HAL function calls
+    # also replace address and the data for input and output glb tiles  
+    with open(input_reg_write_path, 'r') as file:
+        data = file.read()
+        data = data.replace('glb_config()', 'glb_config(int i)')
+        for item in reg_write_input_list:
+            data = data.replace(item, item)
+        for item in reg_write_output_list:
+            data = data.replace(item, item)
+        data = data.replace('glb_reg_write(', 'HAL_Cgra_Glb_WriteReg(0x100 * i + ')
+
+    return data
+
+    

--- a/onyx_codegen/io_placement.py
+++ b/onyx_codegen/io_placement.py
@@ -9,14 +9,14 @@ def unrolling(inputs, outputs, input_order, output_order, f, app_name):
     checkpoint = 0
     f.write("#include \"glb.h\"\n")
     f.write("#include \"" + app_name + "_extents.h\"\n")
-    f.write("int output_mask = 0b111;\n")
+    f.write("const int output_mask = 0b111;\n")
     f.write("\n")
 
     for idx, input_name in enumerate(inputs):
         input_name_str = input_name.replace("hw_", "")
         input_name_str = input_name_str.replace(".raw", "")
-        f.write(f"int {input_name_str}_unroll = {len(input_place_list[idx])};\n")
-        f.write(f"int {input_name_str}_unroll_array[{len(input_place_list[idx])}] = {{")
+        f.write(f"const int {input_name_str}_unroll = {len(input_place_list[idx])};\n")
+        f.write(f"const int {input_name_str}_unroll_array[{len(input_place_list[idx])}] = {{")
         input_str = ", ".join([str(elem) for elem in input_place_list[idx]])
         f.write(input_str)
         f.write(f"}};\n")
@@ -27,7 +27,7 @@ def unrolling(inputs, outputs, input_order, output_order, f, app_name):
     for idx, input_name in enumerate(inputs):
         input_name_str = input_name.replace("hw_", "")
         input_name_str = input_name_str.replace(".raw", "")
-        f.write(f"  write_glb_memory(0x40000 * ({input_name_str}_unroll_array[0]), (uint16_t * ) app_{input_name_str}_data, app_{input_name_str}_data_size / {input_name_str}_unroll, 0, {input_name_str}_unroll);\n")
+        f.write(f"  write_glb_memory(0x20000 * ({input_name_str}_unroll_array[0]), (uint16_t * ) app_{input_name_str}_data, app_{input_name_str}_data_size / {input_name_str}_unroll, 0, {input_name_str}_unroll);\n")
 
         checkpoint = checkpoint + len(input_place_list[idx])
     f.write("}\n\n")
@@ -41,8 +41,8 @@ def unrolling(inputs, outputs, input_order, output_order, f, app_name):
     for io_out in output_place_list:
         stream_pulse_f2g |= (1 << io_out[0])
 
-    f.write(f"int stream_pulse_g2f = {hex(stream_pulse_g2f)};\n")
-    f.write(f"int stream_pulse_f2g = {hex(stream_pulse_f2g)};\n\n")
+    f.write(f"const int stream_pulse_g2f = {hex(stream_pulse_g2f)};\n")
+    f.write(f"const int stream_pulse_f2g = {hex(stream_pulse_f2g)};\n\n")
 
     for idx, input_name in enumerate(inputs):
         input_name_str = input_name.replace("hw_", "")
@@ -60,7 +60,7 @@ def unrolling(inputs, outputs, input_order, output_order, f, app_name):
         input_name_str = input_name_str.replace(".raw", "")
         f.write(f"  {input_name_str}_extents_sum = {input_name_str}_extents[2 * k] * 2;\n")
         f.write(f"  {input_name_str}_extents_len = {input_name_str}_extents[2 * k + 1] - {input_name_str}_extents[2 * k] - 2;\n")
-        f.write(f"  HAL_Cgra_Glb_WriteReg(0x100 * ({input_name_str}_unroll_array[0]) + GLB_LD_DMA_HEADER_0_START_ADDR_R, 0x40000 * ({input_name_str}_unroll_array[0]) + {input_name_str}_extents_sum);\n")
+        f.write(f"  HAL_Cgra_Glb_WriteReg(0x100 * ({input_name_str}_unroll_array[0]) + GLB_LD_DMA_HEADER_0_START_ADDR_R, 0x20000 * ({input_name_str}_unroll_array[0]) + {input_name_str}_extents_sum);\n")
         f.write(f"  HAL_Cgra_Glb_WriteReg(0x100 * ({input_name_str}_unroll_array[0]) + GLB_LD_DMA_HEADER_0_RANGE_0_R, {input_name_str}_extents_len);\n")
         f.write("\n")
     f.write("}\n")

--- a/onyx_codegen/main_codegen.py
+++ b/onyx_codegen/main_codegen.py
@@ -1,22 +1,25 @@
-def main_gen_header_files(file):
+def main_gen_c_lib_include(file):
 
     file.write("#include <stdio.h>\n")
     file.write("#include <stdlib.h>\n")
     file.write("#include \"diag/trace.h\"\n")
-    file.write("#include \"amberm3vx_hal.h\"\n")
-    file.write("#include \"glb.h\"\n")
-    file.write("#include \"glc.h\"\n")
-    file.write("#include \"memory.h\"\n")
-    file.write("#include \"define.h\"\n")
     file.write("\n")
 
-def main_spec_header_files(file, app_name):
+def main_app_header_include(file, app_name):
 
     file.write("#include \"" + app_name + "_script.h\"\n")
     file.write("#include \"" + app_name + "_input_script.h\"\n")
     file.write("#include \"" + app_name + "_unrolling.h\"\n")
     file.write("#include \"" + app_name + "_reg_write.h\"\n")
     file.write("#include \"" + app_name + "_gold.h\"\n")
+    file.write("\n")
+
+def main_gen_soc_lib_include(file):
+    file.write("#include \"amberm3vx_hal.h\"\n")
+    file.write("#include \"glb.h\"\n")
+    file.write("#include \"glc.h\"\n")
+    file.write("#include \"memory.h\"\n")
+    file.write("#include \"define.h\"\n")
     file.write("\n")
 
 def main_block_1(file):
@@ -79,7 +82,7 @@ def main_block_2(file, mapping_dict, op_list):
 
     file.write("\n")
     for i in range(num_tiles):
-        file.write("    input_read_base = AHASOC_CGRA_DATA_BASE + 0x40000 * " + str(i) + ";\n")
+        file.write("    input_read_base = AHASOC_CGRA_DATA_BASE + 0x20000 * " + str(i) + ";\n")
         file.write("    trace_printf(\"first location: %lx\\n\", input_read_base[0]);\n")
 
     file.write("    trace_printf(\"\\nCONFIG GLB\\n\");\n") 
@@ -96,14 +99,14 @@ def main_block_2(file, mapping_dict, op_list):
     file.write("    trace_printf(\"\\n** Run code-gen  **\\n\");\n")
     file.write("\n")
     file.write("    const uint32_t start_addr = 0x0;\n")
-    file.write("    const uint32_t read_start_addr = 0x20000;\n")
+    file.write("    const uint32_t read_start_addr = 0x10000;\n")
 
 def main_block_3(file, mapping_dict, dest):
 
     out_tensor_dim = len(mapping_dict[dest])
     for i in range(out_tensor_dim):
         curr_mapping = mapping_dict[dest][i]    
-        file.write("    uint16_t* output_read_base" + str(i) + " = (uint16_t*) (AHASOC_CGRA_DATA_BASE + read_start_addr + 0x40000*" + str(curr_mapping) + ");\n")
+        file.write("    uint16_t* output_read_base" + str(i) + " = (uint16_t*) (AHASOC_CGRA_DATA_BASE + read_start_addr + 0x20000*" + str(curr_mapping) + ");\n")
     file.write("\n")
 
     for i in range(out_tensor_dim - 1):
@@ -175,9 +178,9 @@ def main_block_3(file, mapping_dict, dest):
 
     for i in range(out_tensor_dim - 1):
         curr_mapping = mapping_dict[dest][i]
-        file.write("        HAL_Cgra_Glb_WriteReg(0x100 * " + str(curr_mapping) + " + GLB_ST_DMA_HEADER_0_START_ADDR_R, 0x20000 + 0x40000 *" + str(curr_mapping) + " + " + dest + "_mode_" + str(i) + "_idx*2);\n")
+        file.write("        HAL_Cgra_Glb_WriteReg(0x100 * " + str(curr_mapping) + " + GLB_ST_DMA_HEADER_0_START_ADDR_R, 0x10000 + 0x20000 *" + str(curr_mapping) + " + " + dest + "_mode_" + str(i) + "_idx*2);\n")
     val_mapping = mapping_dict[dest][out_tensor_dim - 1]
-    file.write("        HAL_Cgra_Glb_WriteReg(0x100 * " + str(val_mapping) + " + GLB_ST_DMA_HEADER_0_START_ADDR_R, 0x20000 + 0x40000 *" + str(val_mapping) + " + " + dest + "_mode_vals_idx*2);\n")
+    file.write("        HAL_Cgra_Glb_WriteReg(0x100 * " + str(val_mapping) + " + GLB_ST_DMA_HEADER_0_START_ADDR_R, 0x10000 + 0x20000 *" + str(val_mapping) + " + " + dest + "_mode_vals_idx*2);\n")
     file.write("\n")
 
     file.write("    }\n")   
@@ -194,10 +197,10 @@ def main_block_3(file, mapping_dict, dest):
     file.write("\n")
     file.write("    int errors = 0;\n")
     file.write("\n")
-    file.write("    uint16_t* output_read_base = AHASOC_CGRA_DATA_BASE + 0x40000*0 + 0x20000;\n")
+    file.write("    uint16_t* output_read_base = AHASOC_CGRA_DATA_BASE + 0x20000*0 + 0x10000;\n")
 
     for i in range(out_tensor_dim):
-        file.write("    output_read_base = AHASOC_CGRA_DATA_BASE + 0x40000*" + str(i) + " + 0x20000;\n")
+        file.write("    output_read_base = AHASOC_CGRA_DATA_BASE + 0x20000*" + str(i) + " + 0x10000;\n")
         file.write("    trace_printf(\"first location: %lx\\n\", output_read_base" + str(i) + "[0]);\n")
 
     file.write("    trace_printf(\"check gold data\\n\");\n")

--- a/src/bf16_op.cpp
+++ b/src/bf16_op.cpp
@@ -1,8 +1,4 @@
 #include "bf16_op.h"
-#include <stdint.h> 
-#include <cassert>
-#include <iostream>
-#include <bitset>
 
 float bf16_add(float input1, float input2) {
     
@@ -116,11 +112,11 @@ std::string float2bfbin(float input, bool return_hex) {
     std::bitset<32> conversion_mask(0xFFFF0000);
 
     // convert to bf16 by masking the lower 16 bits and shifting right 
-    std::bitset<16> bfbin = (input_bin & conversion_mask) >> 16;
+    std::bitset<32> bfbin = (input_bin & conversion_mask) >> 16;
     
     if (return_hex) {
         std::stringstream ss;
-        ss << hex << bfbin.to_ulong();
+        ss << std::hex << bfbin.to_ulong();
         return ss.str();
     } else {
         return std::to_string(bfbin.to_ulong());

--- a/src/bf16_op.cpp
+++ b/src/bf16_op.cpp
@@ -108,3 +108,21 @@ float bf16_mul(float input1, float input2) {
 
     return result_bf16;
 }
+
+float float2bfbin(float input, bool return_hex) {
+
+    // convert the input float to binary
+    std::bitset<32> input_bin(*reinterpret_cast<unsigned int*>(&input));
+    std::bitset<32> conversion_mask(0xFFFF0000);
+
+    // convert to bf16 by masking the lower 16 bits and shifting right 
+    std::bitset<16> bfbin = (input_bin & conversion_mask) >> 16;
+    
+    if (return_hex) {
+        std::stringstream ss;
+        ss << hex << bfbin.to_ulong();
+        return ss.str();
+    } else {
+        return std::to_string(bfbin.to_ulong());
+    }
+}

--- a/src/bf16_op.cpp
+++ b/src/bf16_op.cpp
@@ -109,7 +109,7 @@ float bf16_mul(float input1, float input2) {
     return result_bf16;
 }
 
-float float2bfbin(float input, bool return_hex) {
+std::string float2bfbin(float input, bool return_hex) {
 
     // convert the input float to binary
     std::bitset<32> input_bin(*reinterpret_cast<unsigned int*>(&input));

--- a/src/bf16_op.h
+++ b/src/bf16_op.h
@@ -1,7 +1,9 @@
 #ifndef BF16_OP_H
 #define BF16_OP_H
+#include <string>
 
 float bf16_add(float input1, float input2);
 float bf16_mul(float input1, float input2);
+float float2bfbin(float input, bool return_hex);
 
 #endif

--- a/src/bf16_op.h
+++ b/src/bf16_op.h
@@ -4,6 +4,6 @@
 
 float bf16_add(float input1, float input2);
 float bf16_mul(float input1, float input2);
-float float2bfbin(float input, bool return_hex);
+std::string float2bfbin(float input, bool return_hex);
 
 #endif

--- a/src/bf16_op.h
+++ b/src/bf16_op.h
@@ -1,6 +1,12 @@
 #ifndef BF16_OP_H
 #define BF16_OP_H
+
 #include <string>
+#include <stdint.h> 
+#include <cassert>
+#include <iostream>
+#include <bitset>
+#include <sstream>
 
 float bf16_add(float input1, float input2);
 float bf16_mul(float input1, float input2);

--- a/src/data_parser.cpp
+++ b/src/data_parser.cpp
@@ -64,19 +64,29 @@ int val_data_printer(std::ofstream &header_file, std::string tensor_name, std::s
 	header_file << "uint16_t app_tensor_" << tensor_name << "_mode_" << mode_name << "_data[] " <<  "__attribute__((section(\".app_tensor_" <<  tensor_name << "_mode_" << mode_name << "_data\"))) = {";
 	header_file << "\n";
 
-	if(dtype == "int"){
-		header_file << "0x" << std::hex << std::setw(3) << std::setfill('0') << int(abs(mode_0[0]));
+	header_file << "0x" << std::hex << std::setw(3) << std::setfill('0') << int(abs(mode_0[0]));
+	int run_length = int(abs(mode_0[0]));
 
+	if(dtype == "int"){
 		for(int i = 1; i < mode_0.size(); i++) {
 			header_file << ", ";
 			header_file << "0x" << std::hex << std::setw(3) << std::setfill('0') << int(abs(mode_0[i]));
 		}
 	} else if (dtype == "bf16"){
-		header_file << "0x" << std::hex << std::setw(3) << std::setfill('0') << float2bfbin(mode_0[0], true);
-
-		for (int i = 0; i < mode_0.size(); i++) {
-			header_file << ", ";
-			header_file << "0x" << std::hex << std::setw(3) << std::setfill('0') << float2bfbin(mode_0[i], true);
+		for (int index = 1; index < mode_0.size();) {
+			for (int i = 0; i < run_length; i++) {
+				header_file << ", ";
+				header_file << "0x" << std::hex << std::setw(3) << std::setfill('0') << float2bfbin(mode_0[index], true);
+				index++;
+			}
+			if (index < mode_0.size()) {
+				run_length = int(abs(mode_0[index]));
+				header_file << ", ";
+				header_file << "0x" << std::hex << std::setw(3) << std::setfill('0') << int(abs(mode_0[index]));
+				index++;
+			} else {
+				break;
+			}
 		}
 	}
 

--- a/src/data_parser.cpp
+++ b/src/data_parser.cpp
@@ -1,6 +1,7 @@
 #include "data_parser.h"
 #include <csignal>
 #include <iomanip>
+#include <bitset>
 
 int build_vec(std::vector<int> &vec, std::string file_path) {
     int val;
@@ -163,10 +164,8 @@ int rtl_size_data_printer_3(std::string output_path, std::string tensor_name, in
 
 int output_subtile_printer(float *op_vals, int output_subtile_size, int curr_subtile_num, ofstream &output_gold_file, std::string dtype) {
 
-	if(dtype == "int"){
-
-    	output_gold_file << "const uint16_t gold_" << curr_subtile_num << "_[" << output_subtile_size << "] = {";
-
+    output_gold_file << "const uint16_t gold_" << curr_subtile_num << "_[" << output_subtile_size << "] = {";
+    if(dtype == "int"){
     	for (int pA = 0; pA < output_subtile_size; pA++) {
         	output_gold_file << int(op_vals[pA]);
         	if(pA != output_subtile_size - 1){
@@ -175,10 +174,17 @@ int output_subtile_printer(float *op_vals, int output_subtile_size, int curr_sub
     	} 
     	output_gold_file << "};\n";
 	} 
-
-	// if(dtype == "float"){
-	// 	Float processing 
-	// }
+    
+    if (dtype == "bf16"){
+        for (int pA = 0; pA < output_subtile_size; pA++) {
+            std::bitset<32> op_vals_bin(*reinterpret_cast<unsigned int*>(&op_vals[pA]));
+            output_gold_file << op_vals_bin.to_ulong();
+            if (pA != output_subtile_size - 1){
+                output_gold_file << ", ";
+            }
+        }
+        output_gold_file << "};\n";
+    }
 
     return 0;
 }

--- a/src/data_parser.cpp
+++ b/src/data_parser.cpp
@@ -360,20 +360,25 @@ int codegen_check_gold_tail(ofstream &output_gold_file, int max_run, int tensor_
 		int i  = 0;
 		output_gold_file << "    for(uint16_t i" << i << " = 0; i" << i << " < mode" << i << "_stream_size; i" << i << "++){" << "\n";
 		output_gold_file << "        x" << i << " = read_base_" << i << "[mode" << i << "_idx + mode" << i << "_base + i" << i << "];" << "\n";
-		i++;
-		output_gold_file << "        x" << i << "_dim = read_base_" << i << "[mode" << i << "_idx + i" << i - 1 << " + 2] - read_base_" << i << "[mode" << i << "_idx + i" << i - 1 << " + 1];" << "\n";
-
-		for(int i = 1; i < tensor_dim; i++){
-			output_gold_file << "    for(uint16_t i" << i << " = 0; i" << i << " < x" << i << "_dim; i" << i << "++){" << "\n";
-			output_gold_file << "        x" << i << " = read_base_" << i << "[mode" << i << "_idx + mode" << i << "_base + x" << i << "_idx + i" << i << "];" << "\n";
-			if(i == tensor_dim - 1){
-				output_gold_file << "        check_ptr[" << id_x << "] = read_base_" << tensor_dim << "[vals_idx + x" << i << "_idx + " << "i" << i << " + 1];" << "\n";
-			}
-			else{
-				int j = i + 1; 
-				output_gold_file << "        x" << j << "_dim = read_base_" << j << "[mode" << j << "_idx + i" << j - 1 << " + 2] - read_base_" << j << "[mode" << j << "_idx + i" << j - 1 << " + 1];" << "\n";
+		
+		// the output is a vector
+		if (tensor_dim == 1) {
+			output_gold_file << "        check_ptr[" << id_x << "] = read_base_" << tensor_dim << "[vals_idx + " << "i" << i << " + 1];\n";
+		} else {
+			for(int i = 1; i < tensor_dim; i++){
+				output_gold_file << "        x" << i << "_dim = read_base_" << i << "[mode" << i << "_idx + i" << i - 1 << " + 2] - read_base_" << i << "[mode" << i << "_idx + i" << i - 1 << " + 1];" << "\n";
+				output_gold_file << "    for(uint16_t i" << i << " = 0; i" << i << " < x" << i << "_dim; i" << i << "++){" << "\n";
+				output_gold_file << "        x" << i << " = read_base_" << i << "[mode" << i << "_idx + mode" << i << "_base + x" << i << "_idx + i" << i << "];" << "\n";
+				if(i == tensor_dim - 1){
+					output_gold_file << "        check_ptr[" << id_x << "] = read_base_" << tensor_dim << "[vals_idx + x" << i << "_idx + " << "i" << i << " + 1];" << "\n";
+				}
+				else{
+					int j = i + 1; 
+					output_gold_file << "        x" << j << "_dim = read_base_" << j << "[mode" << j << "_idx + i" << j - 1 << " + 2] - read_base_" << j << "[mode" << j << "_idx + i" << j - 1 << " + 1];" << "\n";
+				}
 			}
 		}
+		
 
 		for(int i = tensor_dim - 1; i > 0; i--){
 			output_gold_file << "    }" << "\n";

--- a/src/data_parser.cpp
+++ b/src/data_parser.cpp
@@ -309,13 +309,13 @@ int codegen_check_gold_unroll_ifdef_open(ofstream &output_gold_file, int select)
 	return 0; 
 }
 
-int codegen_check_gold_outmap(ofstream &output_gold_file, std::string base_id, std::string tile_id){
-	output_gold_file << "            uint16_t * read_base_" << base_id << " = (uint16_t*) (AHASOC_CGRA_DATA_BASE + read_start_addr + " << tile_id << " * 0x40000);" << "\n";
+int codegen_check_gold_outmap(ofstream &output_gold_file, std::string base_id, std::string tile_id, std::string glb_tile_offset){
+	output_gold_file << "            uint16_t * read_base_" << base_id << " = (uint16_t*) (AHASOC_CGRA_DATA_BASE + read_start_addr + " << tile_id << " * " << glb_tile_offset << ");" << "\n";
 	return 0; 
 }
 
-int codegen_check_gold_outmap_unroll(ofstream &output_gold_file, std::string base_id, std::string tile_id){
-	output_gold_file << "            uint16_t * read_base_" << base_id << " = (uint16_t*) (AHASOC_CGRA_DATA_BASE + read_start_addr + " << tile_id << " * 0x40000 + 0x40000 * 8);" << "\n";
+int codegen_check_gold_outmap_unroll(ofstream &output_gold_file, std::string base_id, std::string tile_id, std::string glb_tile_offset){
+	output_gold_file << "            uint16_t * read_base_" << base_id << " = (uint16_t*) (AHASOC_CGRA_DATA_BASE + read_start_addr + " << tile_id << " * " << glb_tile_offset << " + " << glb_tile_offset <<  " * 8);" << "\n";
 	return 0; 
 }
 

--- a/src/data_parser.cpp
+++ b/src/data_parser.cpp
@@ -85,7 +85,7 @@ int val_data_printer(std::ofstream &header_file, std::string tensor_name, std::s
 }
 
 int extent_data_printer(std::ofstream &header_file, std::string tensor_name, std::string mode_name, std::vector<int> extents_mode_0){
-    header_file << "int tensor_" << tensor_name << "_mode_" << mode_name << "_extents" << "[" << extents_mode_0.size() << "] = {";
+    header_file << "const int tensor_" << tensor_name << "_mode_" << mode_name << "_extents" << "[" << extents_mode_0.size() << "] = {";
     header_file << extents_mode_0[0];
     for(int i = 1; i < extents_mode_0.size(); i++){
         header_file << ", " << extents_mode_0[i];
@@ -224,7 +224,7 @@ int subtile_paths_printer(const std::vector<std::string> &subtile_paths,
 }
 
 int header_meta_data(ofstream &header_file, int max_run){
-	header_file << "int runs = " << max_run << ";" << "\n";
+	header_file << "const int runs = " << max_run << ";" << "\n";
 	return 0; 
 } 
 
@@ -262,13 +262,13 @@ int codegen_check_gold_head(ofstream &output_gold_file, int max_run, int tensor_
 	output_gold_file << "    uint16_t vals_idx = 0;" << "\n";	
 	
 	output_gold_file << "\n"; 
-	output_gold_file << "    const uint32_t read_start_addr = 0x20000;" << "\n";
+	output_gold_file << "    const uint32_t read_start_addr = 0x10000;" << "\n";
 
 	return 0;
 } 
 
 int codegen_check_gold_outmap(ofstream &output_gold_file, std::string base_id, std::string tile_id){
-	output_gold_file << "    uint16_t * read_base_" << base_id << " = (uint16_t*) (AHASOC_CGRA_DATA_BASE + read_start_addr + " << tile_id << " * 0x40000);" << "\n";
+	output_gold_file << "    uint16_t * read_base_" << base_id << " = (uint16_t*) (AHASOC_CGRA_DATA_BASE + read_start_addr + " << tile_id << " * 0x20000);" << "\n";
 	return 0; 
 }
 

--- a/src/data_parser.h
+++ b/src/data_parser.h
@@ -5,6 +5,8 @@
 #include <iostream>
 #include <vector>
 #include <string>
+#include "bf16_op.h"
+
 using namespace std;
 
 int build_vec(std::vector<int> &vec, std::string file_path);

--- a/src/data_parser.h
+++ b/src/data_parser.h
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <vector>
 #include <string>
+#include <src/bf16_op.h>
 using namespace std;
 
 int build_vec(std::vector<int> &vec, std::string file_path);

--- a/src/data_parser.h
+++ b/src/data_parser.h
@@ -5,7 +5,6 @@
 #include <iostream>
 #include <vector>
 #include <string>
-#include <src/bf16_op.h>
 using namespace std;
 
 int build_vec(std::vector<int> &vec, std::string file_path);

--- a/src/data_parser.h
+++ b/src/data_parser.h
@@ -21,7 +21,7 @@ int output_subtile_printer(float *op_vals, int output_subtile_size, int curr_sub
 int subtile_paths_printer(const std::vector<std::string> &subtile_paths, const std::string &output_dir, const std::string &kernel_name, const int &batch_size);
 int header_check_gold(ofstream &output_gold_file, int output_subtile_size);
 int header_subtile_dim_decl(ofstream &header_file, int dim_id, int dim_size);
-int codegen_check_gold_head(ofstream &output_gold_file, int max_run, int tensor_dim, int unroll);
+int codegen_check_gold_head(ofstream &output_gold_file, int max_run, int tensor_dim, int unroll, std::string glb_tile_offset);
 int codegen_check_gold_tail(ofstream &output_gold_file, int max_run, int tensor_dim, std::string type);
 int codegen_check_gold_unroll_ifdef_open(ofstream &output_gold_file, int select);
 int codegen_check_gold_unroll_ifdef_close(ofstream &output_gold_file); 

--- a/src/data_parser.h
+++ b/src/data_parser.h
@@ -21,7 +21,7 @@ int output_subtile_printer(float *op_vals, int output_subtile_size, int curr_sub
 int subtile_paths_printer(const std::vector<std::string> &subtile_paths, const std::string &output_dir, const std::string &kernel_name, const int &batch_size);
 int header_check_gold(ofstream &output_gold_file, int output_subtile_size);
 int header_subtile_dim_decl(ofstream &header_file, int dim_id, int dim_size);
-int codegen_check_gold_head(ofstream &output_gold_file, int max_run, int tensor_dim, int unroll, std::string glb_tile_offset);
+int codegen_check_gold_head(ofstream &output_gold_file, int max_run, int tensor_dim, int unroll, std::string glb_bank_offset);
 int codegen_check_gold_tail(ofstream &output_gold_file, int max_run, int tensor_dim, std::string type);
 int codegen_check_gold_unroll_ifdef_open(ofstream &output_gold_file, int select);
 int codegen_check_gold_unroll_ifdef_close(ofstream &output_gold_file); 

--- a/src/data_parser.h
+++ b/src/data_parser.h
@@ -25,8 +25,8 @@ int codegen_check_gold_head(ofstream &output_gold_file, int max_run, int tensor_
 int codegen_check_gold_tail(ofstream &output_gold_file, int max_run, int tensor_dim, std::string type);
 int codegen_check_gold_unroll_ifdef_open(ofstream &output_gold_file, int select);
 int codegen_check_gold_unroll_ifdef_close(ofstream &output_gold_file); 
-int codegen_check_gold_outmap(ofstream &output_gold_file, std::string base_id, std::string tile_id);
-int codegen_check_gold_outmap_unroll(ofstream &output_gold_file, std::string base_id, std::string tile_id);
+int codegen_check_gold_outmap(ofstream &output_gold_file, std::string base_id, std::string tile_id, std::string glb_tile_offset);
+int codegen_check_gold_outmap_unroll(ofstream &output_gold_file, std::string base_id, std::string tile_id, std::string glb_tile_offset);
 int codegen_check_gold_unroll_ifdef_open(int select); 
 int codegen_check_gold_ret(ofstream &output_gold_file); 
 int header_meta_data(ofstream &header_file, std::string label, int max_run);


### PR DESCRIPTION
1. Add venv to gitignore
2. Add opal as supported codegen target
3. Add workaround hack for matmul on onyx and opal (the modes are reordered)
4. Parameterize glb bank offset and glb tile offset base on the codegen target architecture
5. Add command line argument for specifying the bistream, reg_write, and design_meta to use 
6. Rework the header inclusion generation functions in the genearted c code to make it clearer what's being generated
7. Move the reg_write.h generation code out of main.py and to a separate python function